### PR TITLE
default min/max_allowed properties

### DIFF
--- a/scripts/tests/test_pqc_values.py
+++ b/scripts/tests/test_pqc_values.py
@@ -1,0 +1,45 @@
+import unittest
+
+from pqc_values import PQC_Values
+
+class PQCValuesTest(unittest.TestCase):
+
+    def test_properties(self):
+        expected_value = .1
+        stray = .5
+        default_min_allowed = expected_value * (1 - stray)
+        default_max_allowed = expected_value * (1 + stray)
+
+        values = PQC_Values(expected_value=.1)
+
+        self.assertEqual(values.values, [])
+        self.assertEqual(values.expected_value, expected_value)
+        self.assertEqual(values.stray, stray)
+        self.assertEqual(values.min_allowed, default_min_allowed)
+        self.assertEqual(values.max_allowed, default_max_allowed)
+
+        values.min_allowed = 42.
+        self.assertEqual(values.min_allowed, 42.)
+        self.assertEqual(values.max_allowed, default_max_allowed)
+
+        values.max_allowed = 43.
+        self.assertEqual(values.min_allowed, 42.)
+        self.assertEqual(values.max_allowed, 43.)
+
+        values.min_allowed = None
+        self.assertEqual(values.min_allowed, default_min_allowed)
+        self.assertEqual(values.max_allowed, 43.)
+
+        values.max_allowed = None
+        self.assertEqual(values.min_allowed, default_min_allowed)
+        self.assertEqual(values.max_allowed, default_max_allowed)
+
+        stray = .25
+        default_min_allowed = expected_value * (1 - stray)
+        default_max_allowed = expected_value * (1 + stray)
+
+        values.stray = stray
+        self.assertEqual(values.expected_value, expected_value)
+        self.assertEqual(values.stray, stray)
+        self.assertEqual(values.min_allowed, default_min_allowed)
+        self.assertEqual(values.max_allowed, default_max_allowed)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[options]
+test_suite = tests
+
 [flake8]
 exclude =
     .git
@@ -5,3 +8,7 @@ exclude =
     env
     # external modules yield errors
     scripts/ext
+
+[tool:pytest]
+pythonpath = .
+testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='analysis-pqc',
     version='0.6.0',
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['tests', 'scripts']),
     install_requires=[
         'numpy',
         'scipy'
@@ -11,6 +11,5 @@ setup(
     package_data={},
     entry_points={
         'console_scripts': [],
-    },
-    test_suite='tests'
+    }
 )


### PR DESCRIPTION
Applied changes to attributes `expected_value` and `stray` ti instances of class `PQC_Values` where not propagated correctly to attributes `min_allowed` and `max_allowed` (later ones where not updated if not set explicit before).

Implemented `min_allowed` and `max_allowed` as class properties. If set to `None` they will return default values based on attributes `expected_value` and `stray` applying `expected_value * (1. -/+ stray)`.

Updating attributes `expected_value` and/or `stray` but omitting `min_allowed` and/or `max_allowed` using the configuration file now works as expected.